### PR TITLE
Allow woocommerce/action-scheduler ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
 		"pronamic/wp-money": "^2.4",
 		"pronamic/wp-number": "^1.4",
 		"pronamic/wp-pay-logos": "^2.3",
-		"woocommerce/action-scheduler": "^3.9",
+		"woocommerce/action-scheduler": "^3.9 || ^4.0",
 		"wp-pay/core": "^4.32"
 	},
 	"require-dev": {
@@ -83,7 +83,7 @@
 		"pronamic/pronamic-cli": "^1.1",
 		"pronamic/wp-coding-standards": "^2.2",
 		"rector/rector": "^1.2",
-		"roots/wordpress": "^6.0",
+		"roots/wordpress": "^6.8",
 		"solvebeam/wp-hooks-documentor": "^1.5",
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"vimeo/psalm": "^5.24",

--- a/pronamic-pay-gravity-forms.php
+++ b/pronamic-pay-gravity-forms.php
@@ -5,7 +5,7 @@
  * Description: Extend the Pronamic Pay plugin with Gravity Forms support to receive payments through a variety of payment providers.
  *
  * Version: 4.12.1
- * Requires at least: 4.7
+ * Requires at least: 6.8
  * Requires PHP: 8.2
  *
  * Author: Pronamic


### PR DESCRIPTION
Update the `woocommerce/action-scheduler` Composer constraint to also allow the new 4.0 branch using an OR operator.